### PR TITLE
Adds config for the letter opener gem

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,4 +74,8 @@ Rails.application.configure do
   config.solid_queue.connects_to = { database: { writing: :queue } }
   config.cache_store = :solid_cache_store
   config.solid_cache.database = :cache
+
+  # Use letter_opener gem to preview emails in the browser instead of sending them.
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
 end


### PR DESCRIPTION
Configures the Letter Opener gem to preview application emails directly in the browser when running in development mode, making it easier to debug and test email content.