### PR TITLE
Adds registrations controller

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class RegistrationsController < ApplicationController
+  skip_before_action :require_authentication, only: [ :new, :create ]
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      session[:user_id] = @user.id
+      redirect_to root_path, notice: "Welcome, #{@user.account&.name || @user.email_address}!"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:email_address, :password, :password_confirmation)
+  end
+end


### PR DESCRIPTION
This PR adds a RegistrationsController to handle new user sign-ups.

- Introduces new and create actions for rendering the sign-up form and creating a user.

- Allows unauthenticated users to access the registration page by skipping the require_authentication filter for new and create.

- Stores the newly registered user’s ID in the session to automatically log them in after successful registration.